### PR TITLE
fix: 隐藏 PDF 中会出现的音频播放条。

### DIFF
--- a/internal/pdf/pdf.go
+++ b/internal/pdf/pdf.go
@@ -97,6 +97,10 @@ func hideRedundantElements(downloadComments bool) chromedp.ActionFunc {
 			if(audioPlayer){
 				audioPlayer.style.display="none"
 			}
+			var audioFloatBar = document.querySelector('div[class*="audio-float-bar"]');
+			if(audioFloatBar){
+				audioFloatBar.style.display="none"
+			}
 			var leadsWrapper = document.querySelector('div[class^="leads-wrapper"]');
 			if(leadsWrapper){
 				leadsWrapper.style.display="none";


### PR DESCRIPTION
问题复现环境：
M1 Mac：12.3.1

**Before**:
下载的 PDF 中会有音频播放条，会遮挡住文字。
<img width="872" alt="Screen Shot 2022-05-30 at 01 17 07" src="https://user-images.githubusercontent.com/4338052/170883333-97bac4fe-a49f-4b36-8fa2-e0ae11b520cc.png">

---

**After**:
隐藏之后
<img width="882" alt="image" src="https://user-images.githubusercontent.com/4338052/170883371-5dd228cd-f355-4cc9-bd5c-219c20fcd06b.png">
