### PR TITLE
feat: add mp4 format check when detecting already downloaded videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,92 @@ geektime-downloader 支持下载以下极客时间网站资源。
 ### Prerequisites
 
 - Chrome installed
+- FFmpeg installed（视频下载后自动从 ts 转换为 mp4 格式需要 FFmpeg）
+
+#### 安装 FFmpeg
+
+<details>
+<summary>Windows</summary>
+
+1. 前往 [FFmpeg 官网下载页](https://ffmpeg.org/download.html)，点击 Windows 图标，选择 `gyan.dev` 链接
+2. 下载 `ffmpeg-release-essentials.zip`
+3. 解压到任意目录，例如 `C:\ffmpeg`
+4. 将 FFmpeg 的 `bin` 目录添加到系统环境变量 `PATH` 中：
+   - 右键"此电脑" → 属性 → 高级系统设置 → 环境变量
+   - 在"系统变量"中找到 `Path`，点击编辑 → 新建
+   - 添加 `C:\ffmpeg\bin`（根据实际解压路径修改）
+   - 点击确定保存
+5. 打开新的命令行窗口，验证安装：
+   ```bash
+   ffmpeg -version
+   ```
+
+**或者使用包管理器安装：**
+
+```bash
+# 使用 winget
+winget install Gyan.FFmpeg
+
+# 使用 Chocolatey
+choco install ffmpeg
+
+# 使用 Scoop
+scoop install ffmpeg
+```
+
+</details>
+
+<details>
+<summary>macOS</summary>
+
+```bash
+# 使用 Homebrew（推荐）
+brew install ffmpeg
+
+# 验证安装
+ffmpeg -version
+```
+
+</details>
+
+<details>
+<summary>Linux</summary>
+
+**Ubuntu / Debian：**
+
+```bash
+sudo apt update
+sudo apt install ffmpeg
+
+# 验证安装
+ffmpeg -version
+```
+
+**CentOS / RHEL / Fedora：**
+
+```bash
+# Fedora
+sudo dnf install ffmpeg
+
+# CentOS / RHEL（需要 RPM Fusion 仓库）
+sudo yum install epel-release
+sudo yum install https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-$(rpm -E %rhel).noarch.rpm
+sudo yum install ffmpeg
+
+# 验证安装
+ffmpeg -version
+```
+
+**Arch Linux：**
+
+```bash
+sudo pacman -S ffmpeg
+
+# 验证安装
+ffmpeg -version
+```
+
+</details>
 
 ### Install form source
 
@@ -50,7 +136,7 @@ See [release page](https://github.com/nicoxiang/geektime-downloader/releases)
 ## Windows 推荐使用 Windows Terminal 打开
 
 ## cookie 方式登录
-> geektime-downloader.exe --gcid "gcid" --gcess "gcess"
+> geektime-downloader.exe --gcid "GCID" --gcess "GCESS" --output 7 --quality "hd"
 ```
 
 ### Help
@@ -70,7 +156,7 @@ Flags:
       --enterprise              是否下载企业版极客时间资源
   -f, --folder string           专栏和视频课的下载目标位置 (default "C:\\Users\\nico\\geektime-downloader")
       --gcess string            极客时间 cookie 值 gcess
-      --gcid string             极客时间 cookie 值 gcid
+      --gcid string             极客时间 cookie 值 gcid 
   -h, --help                    help for geektime-downloader
       --interval int            下载资源的间隔时间, 单位为秒, 默认1秒 (default 1)
       --log-level string        日志记录级别(debug, info, warn, error, none) (default "info")

--- a/internal/course/downloader.go
+++ b/internal/course/downloader.go
@@ -243,9 +243,10 @@ func (d *CourseDownloader) downloadTextArticle(article geektime.Article, columnD
 
 func (d *CourseDownloader) skipDownloadVideoArticle(article geektime.Article, columnDir string, overwrite bool) bool {
 	dir := columnDir
-	fileName := filenamify.Filenamify(article.Title) + video.TSExtension
-	fullPath := filepath.Join(dir, fileName)
-	if files.CheckFileExists(fullPath) && !overwrite {
+	baseFileName := filenamify.Filenamify(article.Title)
+	tsPath := filepath.Join(dir, baseFileName+video.TSExtension)
+	mp4Path := filepath.Join(dir, baseFileName+video.MP4Extension)
+	if !overwrite && (files.CheckFileExists(tsPath) || files.CheckFileExists(mp4Path)) {
 		return true
 	}
 	return false

--- a/internal/pkg/ffmpeg/ffmpeg.go
+++ b/internal/pkg/ffmpeg/ffmpeg.go
@@ -1,0 +1,101 @@
+package ffmpeg
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/nicoxiang/geektime-downloader/internal/pkg/logger"
+)
+
+// MP4Extension mp4 file extension
+const MP4Extension = ".mp4"
+
+// ConvertToMP4 convert ts file to mp4 using ffmpeg
+// Input: source file path (ts), output directory
+// Output: mp4 file path, error
+func ConvertToMP4(tsFilePath, outputDir string) (string, error) {
+	// Validate input file exists
+	if _, err := os.Stat(tsFilePath); os.IsNotExist(err) {
+		return "", fmt.Errorf("source ts file not found: %s", tsFilePath)
+	}
+
+	// Generate output mp4 file path
+	baseName := filepath.Base(tsFilePath)
+	mp4FileName := baseName[:len(baseName)-len(".ts")] + MP4Extension
+	mp4FilePath := filepath.Join(outputDir, mp4FileName)
+
+	// Check if mp4 already exists
+	if _, err := os.Stat(mp4FilePath); err == nil {
+		logger.Infof("MP4 file already exists, skipping conversion: %s", mp4FilePath)
+		return mp4FilePath, nil
+	}
+
+	// Find ffmpeg executable
+	ffmpegPath, err := findFFmpeg()
+	if err != nil {
+		return "", fmt.Errorf("ffmpeg not found: %w", err)
+	}
+
+	logger.Infof("Converting %s to %s", baseName, mp4FileName)
+
+	// Prepare ffmpeg command
+	// -i: input file
+	// -c copy: copy streams without re-encoding (fast)
+	// -y: overwrite output file without asking
+	args := []string{
+		"-i", tsFilePath,
+		"-c", "copy",
+		"-y",
+		mp4FilePath,
+	}
+
+	cmd := exec.Command(ffmpegPath, args...)
+
+	// Capture output for logging
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("ffmpeg conversion failed: %w, output: %s", err, string(output))
+	}
+
+	logger.Infof("Successfully converted to: %s", mp4FilePath)
+
+	return mp4FilePath, nil
+}
+
+// findFFmpeg finds the ffmpeg executable in the system
+func findFFmpeg() (string, error) {
+	// Try common ffmpeg executable names
+	names := []string{"ffmpeg", "ffmpeg.exe"}
+
+	// First, check if ffmpeg is in PATH
+	for _, name := range names {
+		if path, err := exec.LookPath(name); err == nil {
+			return path, nil
+		}
+	}
+
+	// For Windows, try to find in common installation paths
+	if runtime.GOOS == "windows" {
+		commonPaths := []string{
+			`C:\Program Files\ffmpeg\bin\ffmpeg.exe`,
+			`C:\ffmpeg\bin\ffmpeg.exe`,
+			filepath.Join(os.Getenv("LOCALAPPDATA"), "ffmpeg", "bin", "ffmpeg.exe"),
+		}
+		for _, path := range commonPaths {
+			if _, err := os.Stat(path); err == nil {
+				return path, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("ffmpeg executable not found in PATH or common locations. Please install ffmpeg from https://ffmpeg.org/download.html")
+}
+
+// IsFFmpegAvailable checks if ffmpeg is available in the system
+func IsFFmpegAvailable() bool {
+	_, err := findFFmpeg()
+	return err == nil
+}

--- a/internal/pkg/ffmpeg/ffmpeg_test.go
+++ b/internal/pkg/ffmpeg/ffmpeg_test.go
@@ -1,0 +1,56 @@
+package ffmpeg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsFFmpegAvailable(t *testing.T) {
+	available := IsFFmpegAvailable()
+	t.Logf("FFmpeg available: %v", available)
+
+	if !available {
+		t.Skip("ffmpeg not available, skipping conversion tests")
+	}
+}
+
+func TestConvertToMP4(t *testing.T) {
+	if !IsFFmpegAvailable() {
+		t.Skip("ffmpeg not available, skipping test")
+	}
+
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	// Create a dummy ts file (this won't be a valid video, just testing the command logic)
+	tsFilePath := filepath.Join(tempDir, "test_video.ts")
+	err := os.WriteFile(tsFilePath, []byte("dummy content"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test ts file: %v", err)
+	}
+
+	// Test conversion - this will likely fail due to invalid ts content,
+	// but we're testing the command execution path
+	_, err = ConvertToMP4(tsFilePath, tempDir)
+
+	// We expect an error due to invalid ts content, but the function should execute
+	if err == nil {
+		t.Log("Conversion executed (expected to fail with dummy content)")
+	}
+}
+
+func TestFindFFmpeg(t *testing.T) {
+	path, err := findFFmpeg()
+	if err != nil {
+		t.Logf("FFmpeg not found: %v", err)
+		return
+	}
+
+	t.Logf("Found FFmpeg at: %s", path)
+
+	// Verify the path exists
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Errorf("FFmpeg path exists but file not found: %s", path)
+	}
+}

--- a/internal/video/video.go
+++ b/internal/video/video.go
@@ -22,6 +22,7 @@ import (
 	"github.com/nicoxiang/geektime-downloader/internal/pkg/logger"
 	"github.com/nicoxiang/geektime-downloader/internal/pkg/m3u8"
 	"github.com/nicoxiang/geektime-downloader/internal/video/vod"
+	"github.com/nicoxiang/geektime-downloader/internal/pkg/ffmpeg"
 )
 
 const (
@@ -29,6 +30,8 @@ const (
 
 	// TSExtension ...
 	TSExtension = ".ts"
+	// MP4Extension ...
+	MP4Extension = ".mp4"
 )
 
 // EncryptType enum
@@ -265,6 +268,25 @@ func download(ctx context.Context,
 
 	// Read temp ts files, decrypt and merge into the one final video file
 	err = mergeTSFiles(tempVideoDir, filenamifyTitle, projectDir, decryptKey, isVodEncryptVideo)
+	if err != nil {
+		return err
+	}
+
+	// Convert merged ts file to mp4 format
+	tsFilePath := filepath.Join(projectDir, filenamifyTitle+TSExtension)
+	_, err = ffmpeg.ConvertToMP4(tsFilePath, projectDir)
+	if err != nil {
+		logger.Warnf("Failed to convert ts to mp4: %v, ts file preserved at: %s", err, tsFilePath)
+		// Return nil as ts file is still available
+		return nil
+	}
+
+	// Remove merged ts file after successful mp4 conversion
+	if removeErr := os.Remove(tsFilePath); removeErr != nil {
+		logger.Warnf("Failed to remove ts file after mp4 conversion: %v", removeErr)
+	} else {
+		logger.Infof("Removed ts file after successful mp4 conversion: %s", tsFilePath)
+	}
 
 	return
 }


### PR DESCRIPTION
Previously skipDownloadVideoArticle only checked for .ts files, but after successful ffmpeg conversion the .ts file is deleted and only .mp4 remains. This caused re-downloads of already converted videos.

Now the skip check looks for both .ts and .mp4 files:
- .ts exists -> skip (downloaded but not yet converted)
- .mp4 exists -> skip (downloaded and successfully converted)

Also adds MP4Extension constant to video package and ffmpeg conversion pipeline with automatic ts cleanup after successful conversion.