### PR TITLE
feat: increase the max number of column articles

### DIFF
--- a/internal/geektime/geektime.go
+++ b/internal/geektime/geektime.go
@@ -190,7 +190,7 @@ func (c *Client) columnArticles(cid int) ([]Article, error) {
 			"order":  "earliest",
 			"prev":   0,
 			"sample": false,
-			"size":   500, //get all articles
+			"size":   1000, //get all articles
 		},
 		res,
 	)


### PR DESCRIPTION
This pull request makes a minor adjustment to the `columnArticles` method in `internal/geektime/geektime.go`, increasing the number of articles fetched in a single request.

- Increased the `size` parameter from 500 to 1000 in the API request payload, allowing the method to retrieve more articles per call.

e.g. Opencourse 100024801 has more than 500 articles.